### PR TITLE
Fix 'Kirby\Panel\Panel::area(): Argument #2 ($area) must be of type a…

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@ App::plugin('daandelange/simplestats', [
     'areas' => [
         'simplestats' => function ($kirby) {
 
-            if(!$kirby->user() || !$kirby->user()->hasSimpleStatsPanelAccess()) return null;
+            if(!$kirby->user() || !$kirby->user()->hasSimpleStatsPanelAccess()) return [];
 
             return [
                 // label for the menu and the breadcrumb


### PR DESCRIPTION
When logging in as non-admin user, I get this:

```text
Kirby\Panel\Panel::area(): Argument #2 ($area) must be of type array|string, null given
```

Inside `index.php`, there's this snippet:

![image](https://github.com/CHE1RON/kirby3-simplestats/assets/122524301/e0c87208-85bb-4f9d-b09c-0a1149a6424b)

BUT you have to return an empty array, otherwise .. well, `null given` 😅 

Fixes #37